### PR TITLE
fix: update gh ci runner ubuntu version

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Github Actions Ubuntu 18.04 runner was [deprecated for removal](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/) at 1.12.2022, therefore [last CI runs failed](https://github.com/CPP-KT/cpp-notes/actions/runs/5357420674) 
![image](https://github.com/CPP-KT/cpp-notes/assets/50461190/af30a3cc-fd72-4099-aaa3-d67a154ad686)

 